### PR TITLE
Update Dockerfile to build binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,16 @@
-ARG ARCH="amd64"
-ARG OS="linux"
-FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
-LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
+ARG IMAGE_BUILD_GO=golang:1.17-buster
+ARG IMAGE_BASE=gcr.io/distroless/static-debian10
 
-ARG ARCH="amd64"
-ARG OS="linux"
-COPY .build/${OS}-${ARCH}/amtool       /bin/amtool
-COPY .build/${OS}-${ARCH}/alertmanager /bin/alertmanager
-COPY examples/ha/alertmanager.yml      /etc/alertmanager/alertmanager.yml
+FROM ${IMAGE_BUILD_GO} AS gobase
+WORKDIR /app
+COPY . ./
+RUN make build
 
-RUN mkdir -p /alertmanager && \
-    chown -R nobody:nobody etc/alertmanager /alertmanager
+FROM ${IMAGE_BASE}
+COPY --from=gobase /app/alertmanager /bin/alertmanager
+COPY --from=gobase /app/amtool /bin/amtool
+COPY LICENSE LICENSE
+COPY NOTICE NOTICE
 
 USER       nobody
 EXPOSE     9093


### PR DESCRIPTION
Current Docker builds fail on:
```
Step 7/16 : COPY .build/${OS}-${ARCH}/amtool       /bin/amtool
COPY failed: file not found in build context or excluded by .dockerignore: stat .build/linux-amd64/amtool: file does not exist
```

I believe the Dockerfile is set up to work with upstream's release tooling. We just need it to build, so changing the Dockerfile to be more like our Prometheus fork (https://github.com/GoogleCloudPlatform/prometheus/pull/16/commits/b091644b7299962b468303698bed40dd615261d0#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557)

Testing locally, this build works and the resulting image seems to run in a test gmp setup