### PR TITLE
Update Debian to latest stable release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG IMAGE_BUILD_GO=golang:1.20-buster
-ARG IMAGE_BASE=gcr.io/distroless/static-debian10
+ARG IMAGE_BUILD_GO=golang:1.20-bookworm
+ARG IMAGE_BASE=gcr.io/distroless/static-debian12
 
 FROM ${IMAGE_BUILD_GO} AS gobase
 WORKDIR /app


### PR DESCRIPTION
Need to update to golang:1.20.7 to fix security vulnerabilities.

golang 1.20-buster supports only until golang 1.20.5, it's also the oldoldstable of debian.

golang 1.20-bookworm is the current stable release. https://wiki.debian.org/DebianReleases