### PR TITLE
Use debian 11 to use the latest version of go

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-ARG IMAGE_BUILD_GO=golang:1.20-bookworm
-ARG IMAGE_BASE=gcr.io/distroless/static-debian12
+ARG IMAGE_BUILD_GO=golang:1.20-bullseye
+ARG IMAGE_BASE=gcr.io/distroless/static-debian11
 
 FROM ${IMAGE_BUILD_GO} AS gobase
 WORKDIR /app


### PR DESCRIPTION
Debian 12 is not supported yet.