### PR TITLE
chore: enable cgo and use google buildbase

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,23 @@
-ARG IMAGE_BUILD_GO=golang:1.20-bullseye
-ARG IMAGE_BASE=gcr.io/distroless/static-debian11
+ARG IMAGE_BUILD_GO=google-go.pkg.dev/golang:1.20.14@sha256:6f86d8a81ff191bee8d3ff8b4c193889560b4ca15df373d5084953c5c860190f
+ARG IMAGE_BASE=gke.gcr.io/gke-distroless/libc@sha256:4f834e207f2721977094aeec4c9daee7032c5daec2083c0be97760f4306e4f88
 
 FROM ${IMAGE_BUILD_GO} AS gobase
 WORKDIR /app
 COPY . ./
-RUN make build
+RUN mkdir /etc/alertmanager
+RUN mkdir /alertmanager
+RUN CGO_ENABLED=1 GOEXPERIMENT=boringcrypto \
+    go build \
+    -tags boring \
+    -mod=vendor \
+    -ldflags="-X github.com/prometheus/common/version.Version=$(cat VERSION) \
+    -X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
+    ./cmd/alertmanager
 
 FROM ${IMAGE_BASE}
 COPY --from=gobase /app/alertmanager /bin/alertmanager
-COPY --from=gobase /app/amtool /bin/amtool
+COPY --from=gobase --chown=nobody:nobody /etc/alertmanager /etc/alertmanager
+COPY --from=gobase --chown=nobody:nobody /alertmanager /alertmanager
 COPY LICENSE LICENSE
 COPY NOTICE NOTICE
 

--- a/cmd/alertmanager/boring.go
+++ b/cmd/alertmanager/boring.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build boring
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)


### PR DESCRIPTION
cgo needs to be enabled to link against boringcrypto, so we add that
here.

In addition, we use the google-go.pkg.dev/golang image as the Go
buildbase to ensure build-time requirements, like boringcrypto, are
enabled.

We also use gke.gcr.io/gke-distroless/libc as our runtime image.

We add the "cryp/tls/fipsonly" import to ensure boringcrypto is
linking properly at build time. We guard this with a build tag
"boring" in a dedicated file.

Finally, we move away from promu in our Dockerfile as it was not obvious
how to pass a go build tag through just in the Docker case. We remove
amtool from the image, as its not intended to be used. This involved
mimicing a lot of what we do in the Prometheus fork's Dockerfile.