### PR TITLE
feat: reintroduce amtool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,9 +13,17 @@ RUN CGO_ENABLED=1 GOEXPERIMENT=boringcrypto \
     -ldflags="-X github.com/prometheus/common/version.Version=$(cat VERSION) \
     -X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
     ./cmd/alertmanager
+RUN CGO_ENABLED=1 GOEXPERIMENT=boringcrypto \
+    go build \
+    -tags boring \
+    -mod=vendor \
+    -ldflags="-X github.com/prometheus/common/version.Version=$(cat VERSION) \
+    -X github.com/prometheus/common/version.BuildDate=$(date --iso-8601=seconds)" \
+    ./cmd/amtool
 
 FROM ${IMAGE_BASE}
 COPY --from=gobase /app/alertmanager /bin/alertmanager
+COPY --from=gobase /app/amtool /bin/amtool
 COPY --from=gobase --chown=nobody:nobody /etc/alertmanager /etc/alertmanager
 COPY --from=gobase --chown=nobody:nobody /alertmanager /alertmanager
 COPY LICENSE LICENSE

--- a/cmd/amtool/boring.go
+++ b/cmd/amtool/boring.go
@@ -1,0 +1,21 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//go:build boring
+
+package main
+
+import (
+	_ "crypto/tls/fipsonly"
+)


### PR DESCRIPTION
Fixes https://github.com/GoogleCloudPlatform/prometheus-engine/issues/1066

I tested this by building and deploying it on a live GKE cluster and running:

```bash
$ kubectl exec -n gmp-system alertmanager-0 -c alertmanager -- amtool --alertmanager.url=http://alertmanager:9093 alert
Alertname     Starts At                Summary  State   
AlwaysFiring  2024-07-12 19:08:24 UTC           active 
```

The amtool was intentionally removed in https://github.com/GoogleCloudPlatform/alertmanager/pull/81 but it seems like users still need it!