### PR TITLE
chore: Update Go base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
-# TODO(bwplotka): Move to 1.23 once ARM QEMU building is fixed https://github.com/golang/go/issues/68976
-FROM golang:1.23.4@sha256:7ea4c9dcb2b97ff8ee80a67db3d44f98c8ffa0d191399197007d8459c1453041 AS gobase
+FROM google-go.pkg.dev/golang:1.24.9@sha256:17706709dd6f55af1efb33509fea7f09f54163a1209871224bed4cf297fb6bbb AS gobase
 WORKDIR /app
 COPY . ./
 RUN mkdir /etc/alertmanager


### PR DESCRIPTION
golang:1.24.5 -> golang:1.24.9

Also removed staled todo from dependatbot upgrade (the referred issue is [closed](https://github.com/golang/go/issues/68976))